### PR TITLE
Fix an issue displaying certain long conversations

### DIFF
--- a/desktop-app/index.html
+++ b/desktop-app/index.html
@@ -154,7 +154,7 @@
     <div ng-show="conversation.messages.length == 0">
       No messages yet. Write something!
     </div>
-    <div ng-repeat-start="message in conversation.messages"
+    <div ng-repeat-start="message in conversation.messages track by $index"
          class="{{message.fromMe ? 'from-me' : 'from-them'}}">
       <p ng-if="message.text">{{message.text}}</p>
     </div>


### PR DESCRIPTION
Some long conversations may have duplicate messages coming back from the API.  Adding this attribute ensures that all the messages get rendered.

This should fix issue #17.